### PR TITLE
Refactor RUN_RDM.py for readability and maintainability

### DIFF
--- a/RUN_RDM.py
+++ b/RUN_RDM.py
@@ -1,234 +1,246 @@
-' Libraries'
-import os, shutil, sys, time
+"""Run the RDM workflow for OSeMOSYS scenarios."""
+import os
+import shutil
+import time
 from pathlib import Path
+
 import pandas as pd
 
-'Auxiliar code'
 from workflow import z_auxiliar_code as AUX
 
 start = time.time()
 
-'Read names of scenarios'
+WORKFLOW_DIR = Path("workflow")
+SCENARIOS_DIR = WORKFLOW_DIR / "0_Scenarios"
+EXECUTABLES_DIR = WORKFLOW_DIR / "1_Experiment" / "Executables"
+FUTURES_DIR = WORKFLOW_DIR / "1_Experiment" / "Experimental_Platform" / "Futures"
+MODEL_STRUCTURE_PATH = (
+    WORKFLOW_DIR / "1_Experiment" / "0_From_Confection" / "B1_Model_Structure.xlsx"
+)
+OSEMOSYS_STRUCTURE_PATH = WORKFLOW_DIR / "2_Miscellaneous" / "OSeMOSYS_Structure.xlsx"
+SHAPE_FILE_PATH = WORKFLOW_DIR / "2_Miscellaneous" / "shape_of_demand.csv"
 
-list_scenarios=os.listdir('./workflow/0_Scenarios')
+scenario_files = os.listdir(SCENARIOS_DIR)
 
-'Read timeslices numbers'
-interface_dir = Path('interface_rdm_inputs')
-setup_table = pd.read_csv(interface_dir / 'Setup.csv')
-num_time_slices_SDP = int( setup_table.loc[ 0 ,'Timeslices_model'] )
+interface_dir = Path("interface_rdm_inputs")
+setup_table = pd.read_csv(interface_dir / "Setup.csv")
+num_time_slices_sdp = int(setup_table.loc[0, "Timeslices_model"])
 
-'If you want to run base future the next variable as "Yes", if do not put "No"'
-run_base_future = str( setup_table.loc[ 0 ,'Run_Base_Future'] )
+run_base_future = str(setup_table.loc[0, "Run_Base_Future"])
 
-'If you want to run RDM experiment the next variable as "Yes", if do not put "No"'
-run_RDM = str( setup_table.loc[ 0 ,'Run_RDM'] )
+run_rdm = str(setup_table.loc[0, "Run_RDM"])
 
-'Solver use to solve the problem'
-solver = str( setup_table.loc[ 0 ,'Solver'] )
+solver = str(setup_table.loc[0, "Solver"])
 
-'Name of the OSeMOSYS model use to solve problem'
-osemosys_model = str( setup_table.loc[ 0 ,'OSeMOSYS_Model_Name'] )
+osemosys_model = str(setup_table.loc[0, "OSeMOSYS_Model_Name"])
 
-'Parameters to print'
-parameters_to_print = pd.read_csv(interface_dir / 'To_Print.csv')
+parameters_to_print = pd.read_csv(interface_dir / "To_Print.csv")
 
-if run_base_future == 'Yes':
-    # ' Step 1: Delete ResultsPath param'
-    
-    for i in range(len(list_scenarios)):
-        lines = []
-        # read file
-        with open("./workflow/0_Scenarios/"+list_scenarios[i], 'r') as fp:
-            # read an store all lines into list
+if run_base_future == "Yes":
+    # Step 1: Delete ResultsPath param
+    for scenario in scenario_files:
+        scenario_path = SCENARIOS_DIR / scenario
+        with open(scenario_path, "r") as fp:
             lines = fp.readlines()
-        # Write file
-        with open("./workflow/0_Scenarios/"+list_scenarios[i], 'w') as fp:
-            # iterate each line
-            for number, line in enumerate(lines):
-                if 'ResultsPath' not in line:
+        with open(scenario_path, "w") as fp:
+            for line in lines:
+                if "ResultsPath" not in line:
                     fp.write(line)
-                    
-    print('Step 1 finished')
-    
-    
-    ' Step 2: Clean folders in ./workflow/1_Experiment/0_From_Confection/'
-    
-    dir = './workflow/1_Experiment/0_From_Confection/'
-    for files in os.listdir(dir):
-        path = os.path.join(dir, files)
+
+    print("Step 1 finished")
+
+    # Step 2: Clean folders in ./workflow/1_Experiment/0_From_Confection/
+    target_dir = WORKFLOW_DIR / "1_Experiment" / "0_From_Confection"
+    for files in os.listdir(target_dir):
+        path = target_dir / files
         try:
             shutil.rmtree(path)
         except OSError:
             os.remove(path)
-    
-    print('Step 2 finished')
-    
-    
-    ' Step 3: Obtain ModelStructure & DefaultParams'
-    """Note: all scenarios must have the same sets. We only use one of the scenario
-    files to obtain the model structure and default parameters"""
-    
-    dic_sets = AUX.obtain_structure_file("./workflow/0_Scenarios/"+list_scenarios[0], 
-                              './workflow/1_Experiment/0_From_Confection/B1_Model_Structure.xlsx', 
-                              './workflow/2_Miscellaneous/OSeMOSYS_Structure.xlsx',
-                              num_time_slices_SDP)
-    
-    print('Step 3 finished')
-    
-    ' Step 4: Clean ./workflow/1_Experiment/Executables folder except .py file'
-    
-    # Clean folders
-    dir = './workflow/1_Experiment/Executables/'
-    for files in os.listdir(dir):
-        path = os.path.join(dir, files)
-        if '.py' not in files:
-            try:
-                shutil.rmtree(path)
-            except OSError:
-                os.remove(path)
-    
-    print('Step 4 finished')
-    
-    ' Step 5: Clean ./workflow/1_Experiment/Experimental_Platform/Futures folder except .py file'
-    
-    # Clean folders
-    dir = './workflow/1_Experiment/Experimental_Platform/Futures'
-    for files in os.listdir(dir):
-        path = os.path.join(dir, files)
-        if '.py' not in files:
-            try:
-                shutil.rmtree(path)
-            except OSError:
-                os.remove(path)
-                
-    print('Step 5 finished')
-    
-    ''' Step 6: Create folders in ./workflow/1_Experiment/Executables and ./workflow/1_Experiment/Experimental_Platform/Futures folders 
-    to stores future 0 and multiple futures respectively'''
-    
-    # Create a folder for each scenario        
-    for i in range(len(list_scenarios)):
-        newpath = './workflow/1_Experiment/Executables/' + list_scenarios[i].replace('.txt','')+ '_0' 
-        if not os.path.exists(newpath):
-            os.makedirs(newpath)
-            
-    # Create a folder for each scenario        
-    for i in range(len(list_scenarios)):
-        newpath = './workflow/1_Experiment//Experimental_Platform/Futures/' + list_scenarios[i].replace('.txt','')
-        if not os.path.exists(newpath):
-            os.makedirs(newpath)
-    
-    print('Step 6 finished')
-    
-    ' Step 7: Paste Scenarios future 0 TXT files in ./workflow/1_Experiment/Executables/'
-    
-    for i in range(len(list_scenarios)):
-        source_folder = './workflow/0_Scenarios/'
-        destination_folder = './workflow/1_Experiment/Executables/'+ list_scenarios[i].replace('.txt','')+'_0/'
-        # construct full file path
-        source = source_folder + list_scenarios[i]
-        destination = destination_folder + list_scenarios[i].replace('.txt','')+'_0.txt'
-        # copy files and write with timeslices quantity of the RDM_Interface.xlsx
-        AUX.process_timeslices(source, num_time_slices_SDP, destination)
-    
-            
-    print('Step 7 finished')
-    
-    ' Step 8: Store data with scenarios data'
-    
-    # Store data from executable file
-    for i in range(len(list_scenarios)):
-                
-        # Isolate params in subfiles
-        data_per_param, special_sets = AUX.isolate_params("./workflow/0_Scenarios/"+list_scenarios[i])
-        
-        
-        
-        # Generate CSV parameters files for each scenario
-        list_dataframes, dict_dataframes, parameters_without_values = AUX.generate_df_per_param(list_scenarios[i].replace('.txt',''), 
-                                            data_per_param,
-                                            num_time_slices_SDP)
-        
-        # Create future 0 input dataset'
-        AUX.create_input_dataset_future_0(list_dataframes,
-                                          list_scenarios[i].replace('.txt',''),
-                                          './workflow/1_Experiment/Executables/'+list_scenarios[i].replace('.txt','_0/'))
-        
-    print('Step 8 finished')
-    
 
-    'Step 9: Create future 0 output dataset'
-    
+    print("Step 2 finished")
+
+    # Step 3: Obtain ModelStructure & DefaultParams
+    # Note: all scenarios must have the same sets. We only use one of the scenario
+    # files to obtain the model structure and default parameters.
+    AUX.obtain_structure_file(
+        str(SCENARIOS_DIR / scenario_files[0]),
+        str(MODEL_STRUCTURE_PATH),
+        str(OSEMOSYS_STRUCTURE_PATH),
+        num_time_slices_sdp,
+    )
+
+    print("Step 3 finished")
+
+    # Step 4: Clean ./workflow/1_Experiment/Executables folder except .py file
+    # Clean folders
+    target_dir = EXECUTABLES_DIR
+    for files in os.listdir(target_dir):
+        path = target_dir / files
+        if ".py" not in files:
+            try:
+                shutil.rmtree(path)
+            except OSError:
+                os.remove(path)
+
+    print("Step 4 finished")
+
+    # Step 5: Clean ./workflow/1_Experiment/Experimental_Platform/Futures folder except .py file
+    # Clean folders
+    target_dir = FUTURES_DIR
+    for files in os.listdir(target_dir):
+        path = target_dir / files
+        if ".py" not in files:
+            try:
+                shutil.rmtree(path)
+            except OSError:
+                os.remove(path)
+
+    print("Step 5 finished")
+
+    # Step 6: Create folders for future 0 and multiple futures
+    # Create a folder for each scenario
+    for scenario in scenario_files:
+        scenario_stem = scenario.replace(".txt", "")
+        newpath = EXECUTABLES_DIR / f"{scenario_stem}_0"
+        if not os.path.exists(newpath):
+            os.makedirs(newpath)
+
+    # Create a folder for each scenario
+    for scenario in scenario_files:
+        newpath = FUTURES_DIR / scenario.replace(".txt", "")
+        if not os.path.exists(newpath):
+            os.makedirs(newpath)
+
+    print("Step 6 finished")
+
+    # Step 7: Paste scenarios future 0 TXT files in ./workflow/1_Experiment/Executables/
+    for scenario in scenario_files:
+        scenario_stem = scenario.replace(".txt", "")
+        source_folder = str(SCENARIOS_DIR) + "/"
+        destination_folder = str(EXECUTABLES_DIR / f"{scenario_stem}_0") + "/"
+        # construct full file path
+        source = source_folder + scenario
+        destination = destination_folder + scenario_stem + "_0.txt"
+        # copy files and write with timeslices quantity of the RDM_Interface.xlsx
+        AUX.process_timeslices(source, num_time_slices_sdp, destination)
+    print("Step 7 finished")
+
+    # Step 8: Store data with scenarios data
+    # Store data from executable file
+    for scenario in scenario_files:
+        scenario_stem = scenario.replace(".txt", "")
+
+        # Isolate params in subfiles
+        data_per_param, _ = AUX.isolate_params(str(SCENARIOS_DIR / scenario))
+
+        # Generate CSV parameters files for each scenario
+        list_dataframes, _, _ = AUX.generate_df_per_param(
+            scenario_stem,
+            data_per_param,
+            num_time_slices_sdp,
+        )
+
+        # Create future 0 input dataset
+        AUX.create_input_dataset_future_0(
+            list_dataframes,
+            scenario_stem,
+            "./workflow/1_Experiment/Executables/" + scenario.replace(".txt", "_0/"),
+        )
+
+    print("Step 8 finished")
+
+    # Step 9: Create future 0 output dataset
     # Output
     start1 = time.time()
-    for i in range(len(list_scenarios)):
+    for scenario in scenario_files:
+        scenario_stem = scenario.replace(".txt", "")
         # Run OSeMOSYS for each scenario
-        AUX.run_osemosys(solver,
-                         './workflow/1_Experiment/Executables/'+list_scenarios[i].replace('.txt','_0/'),
-                         './workflow/1_Experiment/Executables/'+list_scenarios[i].replace('.txt','_0/')+list_scenarios[i].replace('.txt','_0.txt'),
-                         './workflow/' + osemosys_model, 
-                         './workflow/1_Experiment/Executables/'+list_scenarios[i].replace('.txt','_0/')+list_scenarios[i].replace('.txt',''))
-        
-        print('Step 9.Input finished')
-        
-        print('Step 9.Output generated. Star long function')
-        # if solver == 'glpk':
-        #     first_list=[list_scenarios[i].replace('.txt','_0')]
-        #     time_range_vector=list()
-        #     for j in range(2015,2071):
-        #         time_range_vector.append(j)
-            
-            
-        #    AUX.create_output_dataset_future_0(0, time_range_vector, first_list,'./workflow/1_Experiment/0_From_Confection/B1_Model_Structure.xlsx')
-        if solver == 'cbc' or solver == 'cplex':
-            AUX.data_processor_new('./workflow/1_Experiment/Executables/'+list_scenarios[i].replace('.txt','_0/')+list_scenarios[i].replace('.txt','_0_Output.sol'),
-                                   './workflow/1_Experiment/0_From_Confection/B1_Model_Structure.xlsx',
-                                   list_scenarios[i].replace('.txt',''),
-                                   str(0),
-                                   solver,
-                                   parameters_to_print,
-                                   'csv')
-        elif solver == 'glpk':
-            AUX.data_processor_new('./workflow/1_Experiment/Executables/'+list_scenarios[i].replace('.txt','_0/')+list_scenarios[i].replace('.txt','_0_Output.txt'),
-                                   './workflow/1_Experiment/0_From_Confection/B1_Model_Structure.xlsx',
-                                   list_scenarios[i].replace('.txt',''),
-                                   str(0),
-                                   solver,
-                                   parameters_to_print,
-                                   'csv')
-        print('Step 9.Output finished')    
-    print('Step 9 finished')
-    end_1 = time.time()
-    time_elapsed_1 = -start1 + end_1
-    print('   The total time producing outputs and storing data of base futures have been: ' + str( time_elapsed_1 ) + ' seconds' )
+        AUX.run_osemosys(
+            solver,
+            "./workflow/1_Experiment/Executables/" + scenario.replace(".txt", "_0/"),
+            "./workflow/1_Experiment/Executables/"
+            + scenario.replace(".txt", "_0/")
+            + scenario.replace(".txt", "_0.txt"),
+            "./workflow/" + osemosys_model,
+            "./workflow/1_Experiment/Executables/" + scenario.replace(".txt", "_0/") + scenario_stem,
+        )
 
-if run_RDM == 'Yes':
-    'Step 10: Execute RDM experiment'
-    print('Start RDM experiment\n')
-    AUX.run_scripts('./workflow/1_Experiment/0_experiment_manager.py', solver, osemosys_model, os.path.abspath('interface_rdm_inputs'), shape_file=os.path.abspath('./workflow/2_Miscellaneous/shape_of_demand.csv'))
-    
-    print('Step 10 finished\n')
-    
-    
-    'Step 11: Execute RDM experiment'
+        print("Step 9.Input finished")
+
+        print("Step 9.Output generated. Star long function")
+        if solver in ("cbc", "cplex"):
+            AUX.data_processor_new(
+                "./workflow/1_Experiment/Executables/"
+                + scenario.replace(".txt", "_0/")
+                + scenario_stem
+                + "_0_Output.sol",
+                str(MODEL_STRUCTURE_PATH),
+                scenario_stem,
+                str(0),
+                solver,
+                parameters_to_print,
+                "csv",
+            )
+        elif solver == "glpk":
+            AUX.data_processor_new(
+                "./workflow/1_Experiment/Executables/"
+                + scenario.replace(".txt", "_0/")
+                + scenario_stem
+                + "_0_Output.txt",
+                str(MODEL_STRUCTURE_PATH),
+                scenario_stem,
+                str(0),
+                solver,
+                parameters_to_print,
+                "csv",
+            )
+        print("Step 9.Output finished")
+    print("Step 9 finished")
+    end_1 = time.time()
+    time_elapsed_1 = end_1 - start1
+    print(
+        "   The total time producing outputs and storing data of base futures have been: "
+        + str(time_elapsed_1)
+        + " seconds"
+    )
+
+if run_rdm == "Yes":
+    # Step 10: Execute RDM experiment
+    print("Start RDM experiment\n")
+    AUX.run_scripts(
+        "./workflow/1_Experiment/0_experiment_manager.py",
+        solver,
+        osemosys_model,
+        os.path.abspath("interface_rdm_inputs"),
+        shape_file=os.path.abspath(str(SHAPE_FILE_PATH)),
+    )
+
+    print("Step 10 finished\n")
+
+    # Step 11: Execute RDM experiment
     start3 = time.time()
-    print('Start Output Dataset Creator\n')
-    AUX.run_scripts('./workflow/1_Experiment/1_output_dataset_creator.py')
-    
-    print('Step 11 finished\n')
+    print("Start Output Dataset Creator\n")
+    AUX.run_scripts("./workflow/1_Experiment/1_output_dataset_creator.py")
+
+    print("Step 11 finished\n")
     end_3 = time.time()
-    time_elapsed_3 = -start3 + end_3
-    print('   The total time producing storing data of the experiment has been: ' + str( time_elapsed_3 ) + ' seconds' )
-    
-if solver == 'cplex':
-    for file in ['cplex.log', 'clone1.log', 'clone2.log']:
+    time_elapsed_3 = end_3 - start3
+    print(
+        "   The total time producing storing data of the experiment has been: "
+        + str(time_elapsed_3)
+        + " seconds"
+    )
+
+if solver == "cplex":
+    for file in ["cplex.log", "clone1.log", "clone2.log"]:
         if os.path.exists(file):
             os.remove(file)
 
-print('#####################################')
-print('Processing completed successfully.')
-print('#####################################')
+print("#####################################")
+print("Processing completed successfully.")
+print("#####################################")
 
 end = time.time()
-time_elapsed = -start + end
-print('   The total time of the workflow has been: ' + str( time_elapsed ) + ' seconds' )
+time_elapsed = end - start
+print("   The total time of the workflow has been: " + str(time_elapsed) + " seconds")


### PR DESCRIPTION
### Motivation
- Make the base-future and RDM workflow script easier to read and maintain while preserving existing behavior and outputs. 
- Reduce ad-hoc string paths and repeated code to lower the chance of errors in a research codebase.

### Description
- Introduced named path constants (`WORKFLOW_DIR`, `SCENARIOS_DIR`, `EXECUTABLES_DIR`, `FUTURES_DIR`, `MODEL_STRUCTURE_PATH`, `OSEMOSYS_STRUCTURE_PATH`, `SHAPE_FILE_PATH`) and replaced repeated string paths with these constants. 
- Replaced index-based loops and ambiguous variable names with clearer iteration over `scenario_files` and a `scenario_stem` for file stems. 
- Normalized configuration variable names (`num_time_slices_sdp`, `run_base_future`, `run_rdm`) and parsing of `Setup.csv` and `To_Print.csv` with consistent string handling. 
- Cleaned and simplified folder-cleaning, folder-creation, file-copying, model-structure extraction, OSeMOSYS execution, and output-processing blocks while keeping logic and call sites to `AUX` functions unchanged. 
- Tidied formatting, whitespace, comments, and print/log messages, and fixed a few time-difference calculations to use `end - start` for clarity without changing their numeric results.

### Testing
- No automated tests were executed as part of this change.
- The change is limited to `RUN_RDM.py` and preserves all external calls and function signatures to avoid behavioural changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b7805f43883208e3f8586698c0fd8)