### PR TITLE
Refactor output dataset creator for readability and YEAR coercion

### DIFF
--- a/workflow/1_Experiment/1_output_dataset_creator.py
+++ b/workflow/1_Experiment/1_output_dataset_creator.py
@@ -1,9 +1,7 @@
-from datetime import date
-import sys
-import pandas as pd
 import os
-import re
-import pyarrow
+import sys
+
+import pandas as pd
 
 # Get the directory of the current script
 current_script_path = os.path.dirname(os.path.abspath(__file__))
@@ -16,11 +14,18 @@ dir_futures = os.path.join(current_script_path, 'Experimental_Platform', 'Future
 sys.path.insert(0, dir_futures)
 import local_dataset_creator_f
 
-'Define control parameters:'
+
+def coerce_year_to_int(dataframe: pd.DataFrame) -> pd.DataFrame:
+    """Ensure YEAR is an integer column, coercing invalid values to zero."""
+    dataframe['YEAR'] = pd.to_numeric(dataframe['YEAR'], errors='coerce')
+    dataframe['YEAR'] = dataframe['YEAR'].fillna(0).astype(int)
+    return dataframe
+
+
 if __name__ == '__main__':
     run_for_first_time = True
     
-    if run_for_first_time == True:
+    if run_for_first_time:
         local_dataset_creator_0.execute_local_dataset_creator_0_outputs(dir_executables)
         local_dataset_creator_f.execute_local_dataset_creator_f_outputs(dir_futures)
         local_dataset_creator_0.execute_local_dataset_creator_0_inputs(dir_executables)
@@ -29,28 +34,17 @@ if __name__ == '__main__':
     ############################################################################################################
     output_dataset_0_path = os.path.join(dir_executables, 'output_dataset_0.csv')
     df_0_output = pd.read_csv(output_dataset_0_path, index_col=None, header=0, low_memory=False)
-    df_0_output['Scen_fut'] = df_0_output['Strategy'].astype(str) + "_" + df_0_output['Future.ID'].astype(str)
+    df_0_output['Scen_fut'] = (
+        df_0_output['Strategy'].astype(str) + "_" + df_0_output['Future.ID'].astype(str)
+    )
     
-    # output_dataset_f_path = os.path.join(dir_futures, 'output_dataset_f.csv')
     output_dataset_f_path = os.path.join(dir_futures, 'output_dataset_f.parquet')
-    # df_f_output = pd.read_csv( output_dataset_f_path, index_col=None, header=0)
     df_f_output = pd.read_parquet(output_dataset_f_path, engine='pyarrow')
 
-    # Reemplazar valores no finitos (NaN, inf, -inf) con un valor predeterminado
-    df_0_output['YEAR'] = pd.to_numeric(df_0_output['YEAR'], errors='coerce')  # Convierte valores no válidos a NaN
-    df_0_output['YEAR'] = df_0_output['YEAR'].fillna(0)  # Rellena NaN con 0 (puedes usar otro valor si prefieres)
-    df_0_output['YEAR'] = df_0_output['YEAR'].astype(int)  # Convierte a int
-    
-    df_f_output['YEAR'] = pd.to_numeric(df_f_output['YEAR'], errors='coerce')  # Convierte valores no válidos a NaN
-    df_f_output['YEAR'] = df_f_output['YEAR'].fillna(0)  # Rellena NaN con 0 (puedes usar otro valor si prefieres)
-    df_f_output['YEAR'] = df_f_output['YEAR'].astype(int)  # Convierte a int
-
-
-    # df_0_output['YEAR'] = df_0_output['YEAR'].astype(int)
-    # df_f_output['YEAR'] = df_f_output['YEAR'].astype(int)
-    li_output = [df_0_output, df_f_output]
-    #
-    df_output = pd.concat(li_output, axis=0, ignore_index=True)
+    df_0_output = coerce_year_to_int(df_0_output)
+    df_f_output = coerce_year_to_int(df_f_output)
+    output_frames = [df_0_output, df_f_output]
+    df_output = pd.concat(output_frames, axis=0, ignore_index=True)
     df_output.sort_values(by=[
         'Strategy', 'Future.ID', 'REGION', 'COMMODITY', 'TECHNOLOGY', 'EMISSION',
         'YEAR', 'TIMESLICE', 'MODE_OF_OPERATION', 'SEASON', 'DAYTYPE',
@@ -60,55 +54,47 @@ if __name__ == '__main__':
     ############################################################################################################
     input_dataset_0_path = os.path.join(dir_executables, 'input_dataset_0.csv')
     df_0_input = pd.read_csv(input_dataset_0_path, index_col=None, header=0, low_memory=False)
-    df_0_input['Scen_fut'] = df_0_input['Strategy'].astype(str) + "_" + df_0_input['Future.ID'].astype(str)
+    df_0_input['Scen_fut'] = (
+        df_0_input['Strategy'].astype(str) + "_" + df_0_input['Future.ID'].astype(str)
+    )
     
-    # input_dataset_f_path = os.path.join(dir_futures, 'input_dataset_f.csv')
     input_dataset_f_path = os.path.join(dir_futures, 'input_dataset_f.parquet')
-    # df_f_input = pd.read_csv(input_dataset_f_path, index_col=None, header=0, low_memory=False)
     df_f_input = pd.read_parquet(input_dataset_f_path, engine='pyarrow')
-    li_intput = [df_0_input, df_f_input]
-    #
-    df_input = pd.concat(li_intput, axis=0, ignore_index=True)
+    input_frames = [df_0_input, df_f_input]
+    df_input = pd.concat(input_frames, axis=0, ignore_index=True)
     df_input.sort_values(by=[
         'Strategy', 'Future.ID', 'REGION', 'COMMODITY', 'TECHNOLOGY', 'EMISSION',
         'YEAR', 'TIMESLICE', 'MODE_OF_OPERATION', 'SEASON', 'DAYTYPE',
         'DAILYTIMEBRACKET', 'STORAGE', 'STORAGEINTRADAY', 'STORAGEINTRAYEAR', 'UDC'
     ], inplace=True)
 
-    # Reemplazar valores no finitos (NaN, inf, -inf) con un valor predeterminado
-    df_output['YEAR'] = pd.to_numeric(df_output['YEAR'], errors='coerce')  # Convierte valores no válidos a NaN
-    df_output['YEAR'] = df_output['YEAR'].fillna(0)  # Rellena NaN con 0 (puedes usar otro valor si prefieres)
-    df_output['YEAR'] = df_output['YEAR'].astype(int)  # Convierte a int
-    
-    df_input['YEAR'] = pd.to_numeric(df_input['YEAR'], errors='coerce')  # Convierte valores no válidos a NaN
-    df_input['YEAR'] = df_input['YEAR'].fillna(0)  # Rellena NaN con 0 (puedes usar otro valor si prefieres)
-    df_input['YEAR'] = df_input['YEAR'].astype(int)  # Convierte a int
+    df_output = coerce_year_to_int(df_output)
+    df_input = coerce_year_to_int(df_input)
 
-    
-    # df_output['YEAR'] = df_output['YEAR'].astype(int)
-    # df_input['YEAR'] = df_input['YEAR'].astype(int)
-    dfa_list = [ df_output, df_input ]
-    
-    today = date.today()
     #
-    # Check if 'Results' folder exists, and create it if not
     if not os.path.exists('Results'):
         os.makedirs('Results')
         print("Folder 'Results' created.")
     else:
         print("Folder 'Results' already exists.")
     #
-    df_output = dfa_list[0]
-    output_path = os.path.join('Results','OSEMOSYS_Energy_Output.csv')
-    df_output.to_csv ( output_path, index = None, header=True)
+    output_path = os.path.join('Results', 'OSEMOSYS_Energy_Output.csv')
+    df_output.to_csv(output_path, index=None, header=True)
     # Also write under 1_Experiment/Results for convenience
-    exp_results_dir = os.path.join('workflow','1_Experiment','Results')
+    exp_results_dir = os.path.join('workflow', '1_Experiment', 'Results')
     if not os.path.exists(exp_results_dir):
         os.makedirs(exp_results_dir)
-    df_output.to_csv(os.path.join(exp_results_dir,'OSEMOSYS_Energy_Output.csv'), index=None, header=True)
+    df_output.to_csv(
+        os.path.join(exp_results_dir, 'OSEMOSYS_Energy_Output.csv'),
+        index=None,
+        header=True,
+    )
     #
-    df_input = dfa_list[1]
-    input_path = os.path.join('Results','OSEMOSYS_Energy_Input.csv')
-    df_input.to_csv ( input_path, index = None, header=True)
+    input_path = os.path.join('Results', 'OSEMOSYS_Energy_Input.csv')
+    df_input.to_csv(input_path, index=None, header=True)
     # Mirror input under 1_Experiment/Results as well
-    df_input.to_csv(os.path.join(exp_results_dir,'OSEMOSYS_Energy_Input.csv'), index=None, header=True)
+    df_input.to_csv(
+        os.path.join(exp_results_dir, 'OSEMOSYS_Energy_Input.csv'),
+        index=None,
+        header=True,
+    )


### PR DESCRIPTION
### Motivation
- Improve readability and clarity of the script that creates combined input/output datasets while preserving exact outputs and filenames.
- Translate Spanish comments and variable hints to English and remove redundant or dead code for easier maintenance by energy-systems researchers.
- Centralize repeated `YEAR` coercion logic to make the numerical assumption explicit and reduce repetition.

### Description
- Add a `coerce_year_to_int(dataframe: pd.DataFrame) -> pd.DataFrame` helper with a concise docstring to coerce `YEAR` to integer and replace invalid values with `0`.
- Replace duplicated `YEAR` coercion blocks with calls to `coerce_year_to_int` for both input and output DataFrames and for concatenated frames.
- Rename small local variables for clarity (`li_output`/`li_intput` -> `output_frames`/`input_frames`), simplify the `run_for_first_time` check to `if run_for_first_time:`, and remove unused variables such as `today`.
- Tidy imports and formatting, remove commented-out code, and clean CSV/Parquet write calls while preserving the exact output file names (`Results/OSEMOSYS_Energy_Output.csv`, `Results/OSEMOSYS_Energy_Input.csv`) and the mirrored `workflow/1_Experiment/Results` copies.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bad0038b08320ad15ebedce75ccf0)