### PR TITLE
Add smoke import test and minimal run_workflow example

### DIFF
--- a/examples/run_workflow.py
+++ b/examples/run_workflow.py
@@ -1,0 +1,10 @@
+"""Run the full RDM Kenya workflow using the bundled inputs.
+
+This script mirrors the README usage and executes the end-to-end pipeline.
+"""
+
+from rdm_kenya.experiment import run_rdm_workflow
+
+
+if __name__ == "__main__":
+    run_rdm_workflow()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,13 @@
+"""Smoke tests to ensure core modules import successfully."""
+
+import rdm_kenya
+from rdm_kenya import analysis, experiment, postprocessing, utils, workflow_utils
+
+
+def test_core_module_imports():
+    assert rdm_kenya.__all__ is not None
+    assert analysis is not None
+    assert experiment is not None
+    assert postprocessing is not None
+    assert utils is not None
+    assert workflow_utils is not None


### PR DESCRIPTION
### Motivation
- Ensure the package's core modules are importable and provide a minimal scripted example to run the end-to-end workflow for users and CI checks.

### Description
- Add `tests/test_imports.py`, a smoke test that imports `rdm_kenya` and its core modules, and add `examples/run_workflow.py`, a minimal script that calls `run_rdm_workflow()` to mirror README usage.

### Testing
- No automated tests were executed in this change; the new smoke test file `tests/test_imports.py` was added for future CI runs and local `pytest` execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9b980dc883208023ca7752e4c760)